### PR TITLE
Do not destructure base64url.decode.

### DIFF
--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -165,7 +165,7 @@ async function _tokenizerFromRecord({record}) {
 
   // 1. Generate capability agent from handle and secret.
   const handle = 'primary';
-  const {secret} = base64url.decode(tokenizer.secret);
+  const secret = base64url.decode(tokenizer.secret);
   const capabilityAgent = await CapabilityAgent.fromSecret({handle, secret});
 
   // 2. Get HMAC API.


### PR DESCRIPTION
base64url.decode just returns a unit8 array not an object with a property secret.