### PR TITLE
Use cborld to express tokens.

### DIFF
--- a/lib/aeskw.js
+++ b/lib/aeskw.js
@@ -22,8 +22,9 @@ class Kek {
     const kek = this.key;
     // Note: `AES-GCM` algorithm name doesn't matter; will be exported raw.
     const extractable = true;
+    const length = unwrappedKey.length * 8;
     unwrappedKey = await crypto.subtle.importKey(
-      'raw', unwrappedKey, {name: 'AES-GCM', length: 256},
+      'raw', unwrappedKey, {name: 'AES-GCM', length},
       extractable, ['encrypt']);
     const wrappedKey = await crypto.subtle.wrapKey(
       'raw', unwrappedKey, kek, kek.algorithm);

--- a/lib/batchVersions.js
+++ b/lib/batchVersions.js
@@ -41,8 +41,6 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     options: {unique: true, background: false}
   }]);
 
-  // FIXME: create shard key
-
   // insert default version options from config, ignoring duplicates
   const options = bedrock.config.tokenization.defaultVersionOptions;
   try {

--- a/lib/batchVersions.js
+++ b/lib/batchVersions.js
@@ -6,9 +6,14 @@ import * as database from 'bedrock-mongodb';
 import {promisify} from 'util';
 const {util: {BedrockError}} = bedrock;
 import LRU from 'lru-cache';
+
+// this cache instance will have keys for batchVersion.tokenizerId and
+// batchVersion.id, there is no possibility of a keyspace collision on these
+// values
 const CACHE = new LRU({
-  // FIXME: what is appropriate size and maxAge?
-  max: 100,
+  max: 20,
+  // 24 hour ttl
+  maxAge: 1000 * 60 * 60 * 24,
 });
 
 const BATCH_OPTIONS_ID = 'NEXT_OPTIONS';

--- a/lib/batchVersions.js
+++ b/lib/batchVersions.js
@@ -5,6 +5,11 @@ import * as bedrock from 'bedrock';
 import * as database from 'bedrock-mongodb';
 import {promisify} from 'util';
 const {util: {BedrockError}} = bedrock;
+import LRU from 'lru-cache';
+const CACHE = new LRU({
+  // FIXME: what is appropriate size and maxAge?
+  max: 100,
+});
 
 const BATCH_OPTIONS_ID = 'NEXT_OPTIONS';
 
@@ -141,6 +146,14 @@ export async function get({id, tokenizerId}) {
     }
     query['batchVersion.tokenizerId'] = tokenizerId;
   }
+
+  const cacheKey =
+    query['batchVersion.tokenizerId'] || query['batchVersion.id'];
+  const cacheResult = CACHE.get(cacheKey);
+  if(cacheResult) {
+    return cacheResult;
+  }
+
   const projection = {_id: 0};
   const collection = database.collections['tokenization-batchVersion'];
   const record = await collection.findOne(query, {projection});
@@ -153,6 +166,9 @@ export async function get({id, tokenizerId}) {
       'Token version not found.',
       'NotFoundError', details);
   }
+
+  CACHE.set(cacheKey, record);
+
   return record;
 }
 

--- a/lib/cit-v1.jsonld
+++ b/lib/cit-v1.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@protected": "true",
+    "type": "@type",
+    "ConcealedIdTokenCredential": "https://w3id.org/cit#ConcealedIdTokenCredential",
+    "concealedIdToken": {
+      "@id": "https://w3id.org/cit#concealedIdToken",
+      "@type": "@id"
+    },
+    "ConcealedIdToken": {
+      "@id": "https://w3id.org/cit#ConcealedIdToken",
+      "@context": {
+        "@protected": true,
+        "meta": {"@id": "https://w3id.org/cit#meta", "@type": "https://w3id.org/security#multibase"},
+        "payload": {"@id": "https://w3id.org/cit#payload", "@type": "https://w3id.org/security#multibase"}
+      }
+    }
+  }
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,5 +10,7 @@ config.tokenization.defaultVersionOptions = {
   batchIdSize: 16,
   batchSaltSize: 16,
   // max tokens in a given batch, must be <= max supported by `batchIndexSize`
-  batchTokenCount: 100
+  batchTokenCount: 100,
+  // time to live in milliseconds, default to 60 days
+  ttl: 60 * 24 * 60 * 60 * 1000
 };

--- a/lib/documentLoader.js
+++ b/lib/documentLoader.js
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ */
+import fs from 'fs';
+
+// TODO: move to another npm package
+const CIT_CONTEXT = JSON.parse(fs.readFileSync(
+  __dirname + '/cit-v1.jsonld', 'utf8'));
+export const CIT_CONTEXT_URL = 'https://w3id.org/cit/v1.jsonld';
+
+export async function documentLoader(url) {
+  if(url !== CIT_CONTEXT_URL) {
+    throw new Error(`Loading document "${url}" is not allowed.`);
+  }
+  return JSON.stringify(CIT_CONTEXT);
+  // FIXME: use this return value once cborld module is patched
+  /*
+  return {
+    contextUrl: null,
+    document: CIT_CONTEXT,
+    documentUrl: url
+  };*/
+}

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -46,7 +46,7 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     }
   }]);
 
-  // FIXME: create shard key
+  // FIXME: create `externalIdHash` shard key
 });
 
 /**

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -207,7 +207,7 @@ async function _insertRegistration({
     }
   };
   if(creatorHash) {
-    record.registration.creatorHash = creatorHash;
+    record.registration.creatorHash = [creatorHash];
   }
   try {
     const result = await collection.insertOne(record, database.writeOptions);

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -26,7 +26,7 @@ const idEncoder = new IdEncoder({
 bedrock.events.on('bedrock-mongodb.ready', async () => {
   await promisify(database.openCollections)(['tokenization-registration']);
 
-  // `externalIdHash` is a shard key
+  // `externalIdHash` should be a shard key
   await promisify(database.createIndexes)([{
     // there may be multiple documents that match the same external ID hash
     // and queries must be supported to find them all...
@@ -45,8 +45,6 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
       expireAfterSeconds: 0
     }
   }]);
-
-  // FIXME: create `externalIdHash` shard key
 });
 
 /**

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -44,20 +44,18 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
   ]);
 
   await promisify(database.createIndexes)([{
-    // tokens are sharded by batch ID -- can't shard by `internalId` because
-    // it will not be known at query time because it is not shared externally
-    // and can't make this index unique because the collection is sharded on
-    // a field that isn't part of it; however, uniqueness is handled by the
-    // index below and by the randomness property of batch IDs
+    // token batches are sharded by `tokenBatch.id` -- can't shard by
+    // `internalId` because it will not be known at query time because it is
+    // not shared externally and can't make this index unique because the
+    // collection is sharded on a field that isn't part of it; however,
+    // uniqueness is handled by the index below and by the randomness property
+    // of batch IDs
     collection: 'tokenization-tokenBatch',
-    // FIXME: may be able to include `batchVersion.id` in this index, and
-    // shrink batch ID size to minimum of 8 bytes if it becomes a shardKey
-    // and this becomes a unique index
     fields: {'tokenBatch.id': 1},
     options: {unique: false, background: false}
   }, {
-    // `internalId` is a shard key, but we rely upon infeasibly large random
-    // batch IDs to ensure uniqueness for batches across `internalId`
+    // `internalId` is a NOT shard key, but we rely upon infeasibly large
+    // random batch IDs to ensure uniqueness for batches across `internalId`
     collection: 'tokenization-tokenBatch',
     fields: {'tokenBatch.internalId': 1, 'tokenBatch.id': 1},
     options: {unique: true, background: false}
@@ -82,7 +80,7 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     options: {unique: true, background: false}
   }]);
 
-  // FIXME: create shard key
+  // FIXME: create `tokenBBatch.id` shard key
 });
 
 /**

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -85,9 +85,6 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     },
     options: {unique: true, background: false}
   }]);
-
-  // FIXME: create `tokenBatch.id` shard key on `tokenBatch` and
-  // `tokenBatch.internalId`
 });
 
 /**

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,18 +1,22 @@
 /*!
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
-import * as base64url from 'base64url-universal';
-import * as bedrock from 'bedrock';
-import * as database from 'bedrock-mongodb';
-import {tokenizers} from 'bedrock-tokenizer';
-import {IdGenerator, IdEncoder} from 'bnid';
-import crypto from 'crypto';
 import assert from 'assert-plus';
+import * as base58 from 'base58-universal';
+import * as base64url from 'base64url-universal';
+import * as batchVersions from './batchVersions.js';
+import * as bedrock from 'bedrock';
+import {createKek} from './aeskw.js';
+import crypto from 'crypto';
+import {CIT_CONTEXT_URL, documentLoader} from './documentLoader.js';
+import * as database from 'bedrock-mongodb';
+import {encode as cborldEncode, decode as cborldDecode} from
+  '@digitalbazaar/cborld';
+import {tokenizers} from 'bedrock-tokenizer';
 import pLimit from 'p-limit';
 import {promisify} from 'util';
-import {createKek} from './aeskw.js';
 import Bitstring from '@digitalbazaar/bitstring';
-import * as batchVersions from './batchVersions.js';
+import {IdGenerator, IdEncoder} from 'bnid';
 const {util: {BedrockError}} = bedrock;
 const {randomBytes, timingSafeEqual} = crypto;
 const randomBytesAsync = promisify(randomBytes);
@@ -21,9 +25,6 @@ const randomBytesAsync = promisify(randomBytes);
 const BATCH_INDEX_SIZE_1 = 'H4sIAAAAAAAAA2NgwA8ArVUKGSAAAAA';
 
 const VERSION_SIZE = 2;
-const UNWRAPPED_SIZE = 24;
-const WRAPPED_SIZE = UNWRAPPED_SIZE + 8;
-const MAX_AAD_SIZE = 8;
 const INTERNAL_ID_SIZE = 23;
 const MAX_TOKEN_COUNT = 100;
 const MIN_TOKEN_COUNT = 0;
@@ -60,6 +61,15 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     collection: 'tokenization-tokenBatch',
     fields: {'tokenBatch.internalId': 1, 'tokenBatch.id': 1},
     options: {unique: true, background: false}
+  }, {
+    // automatically expire toke batches with an `expires` date field
+    collection: 'tokenization-tokenBatch',
+    fields: {'tokenBatch.expires': 1},
+    options: {
+      unique: false,
+      background: false,
+      expireAfterSeconds: 0
+    }
   }, {
     // `internalId` is a shard key for the pairwise token collection as some
     // resolution parties may resolve most tokens in the system so using the
@@ -121,8 +131,10 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
  * @param {Uint8Array} [options.attributes] - Attributes that will be encoded
  *   in each token such that they can be authenticated but also such that
  *   they will appear in the clear for users of the token. Attributes are
- *   expected to be encoded in an application-specific way to fit within a
- *   maximum of 8 bytes.
+ *   expected to be encoded in an application-specific way; every 8 bytes
+ *   of attributes increases the token size by 8 bytes, i.e., 7 bytes of
+ *   attributes will not increase the token size, but 8-15 will increase it by
+ *   8 bytes and 16-23 will increase it by 16, and so on.
  * @param {number} options.tokenCount - The number of tokens to create
  *   in this call; note that this is NOT the batch size and that created tokens
  *   may belong to a number of different token batches.
@@ -136,9 +148,6 @@ export async function create(
 
   if(!(attributes instanceof Uint8Array)) {
     throw new TypeError('"attributes" must be a Uint8Array.');
-  }
-  if(attributes.length > MAX_AAD_SIZE) {
-    throw new RangeError(`"attributes" maximum size is ${MAX_AAD_SIZE} bytes.`);
   }
   if(internalId.length !== INTERNAL_ID_SIZE) {
     throw new RangeError(`"internalId.length" must be ${INTERNAL_ID_SIZE}.`);
@@ -336,31 +345,28 @@ async function _createToken({
   const batchId = base64url.decode(tokenBatch.id);
 
   // get version options
-  const {id: version, options: {batchSaltSize}} = batchVersion;
+  const {id: version, options: {batchIdSize, batchSaltSize}} = batchVersion;
 
-  // TODO: convert `attributes` to CBOR-LD
-  // const cborldBytes = await cborld.encode({jsonldDocument: attributes});
-
-  // TODO: remove `aadSize`
-  // build data to encrypt/wrap: batchId|index|aadSize|aad|padding
-  // total = 192-bits, 24 bytes
-  // TODO: minimum is 24 bytes, max is unlimited; size should depend on
-  // size of cborld encoded attributes
-  const toWrap = new Uint8Array(UNWRAPPED_SIZE);
+  // build data to encrypt/wrap: batchId|index|aad|padding
+  // minimum total = 192-bits, 24 bytes, but can be larger, must be
+  // 24 + (n*8) bytes, where n >= 0
+  // "aad" is additional authenticated data which is aka "attributes"
+  // Note: minimum size is 24 bytes, max is unlimited; size depends on the
+  // size of the attributes
+  const unwrappedSize = _roundToMultipleOf8(
+    batchIdSize + 1 + attributes.length);
+  const toWrap = new Uint8Array(unwrappedSize);
   let dv = new DataView(toWrap.buffer, toWrap.byteOffset, toWrap.length);
   let offset = 0;
   // batch ID, `batchIdSize`, default is 16 bytes
   toWrap.set(batchId, offset);
   // index, 1 byte
   toWrap[offset += batchId.length] = index;
-  // TODO: remove `aadSize`, not needed, to be determined from the cleartext
-  // on the token...
-  // aadSize, 1 byte
-  toWrap[offset += 1] = attributes.length;
-  // TODO: use `cborldBytes`, skipping first 3 bytes...
-  // attributes (up to 8 bytes max, but affects token size)
+  // attributes (unlimited size, but affects token size, largest it can be
+  // without growing the token is 7 bytes, every multiple of 8 thereafter
+  // increases the token size by 8), attributes also travel in the
+  // clear in the token and their size within the wrapped data must match
   toWrap.set(attributes, offset += 1);
-  // TODO: pad to the next multiple of 8 bytes...
   // random padding for remaining bytes
   offset += attributes.length;
   const padding = await randomBytesAsync(toWrap.length - offset);
@@ -369,31 +375,42 @@ async function _createToken({
   // generate salt based on token version options
   const salt = await randomBytesAsync(batchSaltSize);
 
-  // create KEK via HMAC(version|salt)
+  // create KEK via HMAC(batchVersion|salt)
   const kek = await _getKek({hmac, version, salt});
 
   // wrap `toWrap` as if it were a key, output is 8 more bytes than input
+  // per AES-KW spec
   const wrapped = await kek.wrapKey({unwrappedKey: toWrap});
 
-  // build token: version|salt|wrapped|attributes(aad)
+  // build "ConcealedIdToken" payload: batchVersion|salt|wrapped
   // example `tokenSize`:
-  // 2 bytes: version
+  // 2 bytes: batchVersion
   // 16 bytes: salt (larger reduces key collisions, but increases token size)
-  // 32 bytes: wrapped data
-  // 8 bytes: attributes (max of 8, can be 0 to reduce token by 8 bytes)
-  // = 58 byte token max, 50 bytes minimum
-  const tokenSize = 2 + salt.length + wrapped.length + attributes.length;
-  const token = new Uint8Array(tokenSize);
-  dv = new DataView(token.buffer, token.byteOffset, token.length);
+  // 32 bytes: wrapped data (minimum, can be larger by multiples of 8)
+  const payloadSize = 2 + salt.length + wrapped.length;
+  const payload = new Uint8Array(payloadSize);
+  dv = new DataView(payload.buffer, payload.byteOffset, payload.length);
   offset = 0;
-  // version, 2 byte uint16
+  // batchVersion, 2 byte uint16
   dv.setUint16(offset, version);
   // salt
-  token.set(salt, offset += 2);
+  payload.set(salt, offset += 2);
   // wrapped
-  token.set(wrapped, offset += salt.length);
-  // attributes
-  token.set(attributes, offset += wrapped.length);
+  payload.set(wrapped, offset += salt.length);
+
+  // ConcealedIdToken "meta" is "attributes"
+
+  // total token size
+  // = 50 bytes minimum with attributes up to 7 bytes in size, then additional
+  //   multiples of 8 bytes for every multiple of 8 in attributes size
+  const jsonldDocument = {
+    '@context': CIT_CONTEXT_URL,
+    type: 'ConcealedIdToken',
+    // FIXME: check to ensure this is the proper encoding
+    meta: `z${base58.encode(attributes)}`,
+    payload: `z${base58.encode(payload)}`,
+  };
+  const token = await cborldEncode({jsonldDocument, documentLoader});
   return token;
 }
 
@@ -405,29 +422,62 @@ async function _parseToken({token}) {
       'or more in size.');
   }
 
-  // parse version from token
-  const dv = new DataView(token.buffer, token.byteOffset, token.length);
+  // parse token via cborld
+  // token is CBOR-LD encoded "ConcealedIdToken" with a
+  // "payload" and optional "meta"
+  const parsed = {};
+  try {
+    const {type, payload, meta} = await cborldDecode(
+      {cborldBytes: token, documentLoader});
+    if(type !== 'ConcealedIdToken') {
+      throw new Error(`Invalid token type "${type}".`);
+    }
+
+    // decode payload and meta
+    if(!(payload && typeof payload === 'string' && payload[0] === 'z')) {
+      throw new Error(`Invalid token payload "${payload}".`);
+    }
+    parsed.payload = base58.decode(payload.substr(1));
+
+    if(meta) {
+      if(!(meta && typeof meta === 'string' && meta[0] === 'z')) {
+        throw new Error(`Invalid token meta "${meta}".`);
+      }
+      parsed.attributes = base58.decode(meta.substr(1));
+    } else {
+      parsed.attributes = new Uint8Array();
+    }
+  } catch(e) {
+    throw new BedrockError(
+      'Invalid token.',
+      'DataError', {
+        public: true,
+        httpStatusCode: 400
+      }, e);
+  }
+
+  // parse batch version from token payload
+  const {payload, attributes} = parsed;
+  const dv = new DataView(payload.buffer, payload.byteOffset, payload.length);
   const version = dv.getUint16(0);
 
   // get token version by `version` ID
   const {batchVersion} = await batchVersions.get({id: version});
   const {options: {batchIdSize, batchSaltSize}} = batchVersion;
 
-  // TODO: `wrapped` can be larger than 32 bytes, 32 is just the minimum
-
-  // validate token is appropriate size
-  // format: version|salt|wrapped|attributes(aad)
-  // version = 2 bytes
+  // validate payload size is correct given the batch version
+  // payload will contain: batchVersion|salt|wrapped
+  // batchVersion = 2 bytes
   // salt = batchSaltSize bytes
-  // wrapped = 32 bytes
-  // attributes size only known once `wrapped` is unwrapped
-  // Note: `version` and `salt` map to crypto used to generate a key and will
-  // therefore be authenticated via key unwrapping. The `attributes` can be
-  // compared against the unwrapped attributes to be authenticated as well
-  const minimumSize = VERSION_SIZE + batchSaltSize + WRAPPED_SIZE;
-  // 8 bytes is maximum size for attributes
-  const maximumSize = minimumSize + MAX_AAD_SIZE;
-  if(token.length < minimumSize || token.length > maximumSize) {
+  // wrapped = _roundToMultipleOf8(batchIdSize + 1(batchIndex) +
+  //   attributes.length) + 8
+  // Note: `batchVersion` and `salt` map to crypto used to generate a key and
+  // will therefore be authenticated via key unwrapping. The `attributes` can
+  // be compared against the unwrapped attributes to be integrity checked
+  const wrappedSize = _roundToMultipleOf8(
+    batchIdSize + 1 + attributes.length) + 8;
+  const payloadSize = VERSION_SIZE + batchSaltSize + wrappedSize;
+  if(payload.length !== payloadSize) {
     throw new BedrockError(
       'Invalid token.',
       'DataError', {
@@ -436,13 +486,12 @@ async function _parseToken({token}) {
       });
   }
 
-  // parse `salt` and `wrapped` and `attributes`
-  let offset = token.byteOffset + VERSION_SIZE;
-  const salt = new Uint8Array(token.buffer, offset, batchSaltSize);
+  // parse `salt` and `wrapped` from `payload`
+  let offset = payload.byteOffset + VERSION_SIZE;
+  const salt = new Uint8Array(payload.buffer, offset, batchSaltSize);
   const wrapped = new Uint8Array(
-    token.buffer, offset += batchSaltSize, WRAPPED_SIZE);
-  const attributes = new Uint8Array(
-    token.buffer, offset += WRAPPED_SIZE, token.length - minimumSize);
+    payload.buffer, offset += batchSaltSize, wrappedSize);
+
   // get tokenizer associated with version
   const tokenizer = await tokenizers.get({id: batchVersion.tokenizerId});
   const {hmac} = tokenizer;
@@ -466,21 +515,17 @@ async function _parseToken({token}) {
       }, e);
   }
 
-  // at this point, unwrapped is authenticated and known to be 32 bytes
+  // at this point, unwrapped is authenticated
   // next, determine if full token is valid
 
-  // parse unwrapped: batchId|index|aadSize|aad|padding
+  // parse unwrapped: batchId|index|aad|padding
   offset = unwrapped.byteOffset;
   const batchId = new Uint8Array(unwrapped.buffer, offset, batchIdSize);
   const index = unwrapped[batchIdSize];
-  const aadSize = unwrapped[batchIdSize + 1];
   // time-safe compare `aad` against given attributes
-  // always use length of *given* `attributes` to determine what to compare
-  // and then compare actual lengths thereafter
   const toCompare = new Uint8Array(
     unwrapped.buffer, offset + batchIdSize + 1, attributes.length);
-  if(!(timingSafeEqual(toCompare, attributes) &&
-    aadSize === attributes.length)) {
+  if(!timingSafeEqual(toCompare, attributes)) {
     // cleartext attributes are not authenticated
     throw new BedrockError(
       'Invalid token.',
@@ -506,7 +551,7 @@ async function _getKek({hmac, version, salt}) {
 }
 
 async function _createBatch({internalId, batchVersion, tokenCount = 0}) {
-  const {options: {batchIdSize, batchTokenCount}} = batchVersion;
+  const {options: {batchIdSize, batchTokenCount, ttl}} = batchVersion;
   // _randomBytesAsync declared here to support stubbing in the test suite.
   const _randomBytesAsync = promisify(crypto.randomBytes);
 
@@ -519,8 +564,11 @@ async function _createBatch({internalId, batchVersion, tokenCount = 0}) {
   // auto-claim tokens in batch
   const remainingTokenCount = Math.max(0, batchTokenCount - tokenCount);
 
-  const collection = database.collections['tokenization-tokenBatch'];
+  // determine expiration date for batch
   const now = Date.now();
+  const expires = new Date(now + ttl);
+
+  const collection = database.collections['tokenization-tokenBatch'];
   const meta = {created: now, updated: now};
   let record = {
     meta,
@@ -530,7 +578,8 @@ async function _createBatch({internalId, batchVersion, tokenCount = 0}) {
       batchVersion: batchVersion.id,
       resolvedList,
       maxTokenCount: batchTokenCount,
-      remainingTokenCount
+      remainingTokenCount,
+      expires
     }
   };
   try {
@@ -701,4 +750,8 @@ async function _getPairwiseToken({internalId, requester}) {
       'NotFoundError', details);
   }
   return record;
+}
+
+function _roundToMultipleOf8(x) {
+  return Math.ceil(x / 8) * 8;
 }

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -63,8 +63,8 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     // not including `tokenBatch` as an object to nest `internalId` in is
     // intentional, we're only tracking `internalId` and `batchId` in
     // this collection
-    fields: {internalId: 1},
-    options: {unique: false, background: false}
+    fields: {internalId: 1, batchId: 1},
+    options: {unique: true, background: false}
   }, {
     // automatically expire toke batches with an `expires` date field
     collection: 'tokenization-tokenBatch',

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -40,25 +40,31 @@ const idEncoder = new IdEncoder({
 
 bedrock.events.on('bedrock-mongodb.ready', async () => {
   await promisify(database.openCollections)([
-    'tokenization-tokenBatch', 'tokenization-pairwiseToken'
+    'tokenization-tokenBatch', 'tokenization-openTokenBatch',
+    'tokenization-pairwiseToken'
   ]);
 
   await promisify(database.createIndexes)([{
-    // token batches are sharded by `tokenBatch.id` -- can't shard by
-    // `internalId` because it will not be known at query time because it is
-    // not shared externally and can't make this index unique because the
-    // collection is sharded on a field that isn't part of it; however,
-    // uniqueness is handled by the index below and by the randomness property
-    // of batch IDs
+    /* Note: The `tokenBatch` collection is sharded by `tokenBatch.id`. This
+    collection stores the batch information and is separate from the
+    `openTokenBatch` collection that just tracks which batches are unfilled
+    (more tokens can still be issued from them). These collections are
+    independent because they require different sharding characteristics to
+    support different queries. The `tokenBatch` query must support look ups
+    on *only* the `tokenBatch.id` so this must be its shard key. */
     collection: 'tokenization-tokenBatch',
     fields: {'tokenBatch.id': 1},
-    options: {unique: false, background: false}
-  }, {
-    // `internalId` is a NOT shard key, but we rely upon infeasibly large
-    // random batch IDs to ensure uniqueness for batches across `internalId`
-    collection: 'tokenization-tokenBatch',
-    fields: {'tokenBatch.internalId': 1, 'tokenBatch.id': 1},
     options: {unique: true, background: false}
+  }, {
+    // the `openTokenBatch` collection must support look ups on `internalId`
+    // without any token batch ID, so its shard key is only `internalId`; see
+    // above note on `tokenBatch` collection index for more details
+    collection: 'tokenization-openTokenBatch',
+    // not including `tokenBatch` as an object to nest `internalId` in is
+    // intentional, we're only tracking `internalId` and `batchId` in
+    // this collection
+    fields: {internalId: 1},
+    options: {unique: false, background: false}
   }, {
     // automatically expire toke batches with an `expires` date field
     collection: 'tokenization-tokenBatch',
@@ -80,7 +86,8 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     options: {unique: true, background: false}
   }]);
 
-  // FIXME: create `tokenBBatch.id` shard key
+  // FIXME: create `tokenBatch.id` shard key on `tokenBatch` and
+  // `tokenBatch.internalId`
 });
 
 /**
@@ -594,6 +601,17 @@ async function _createBatch({internalId, batchVersion, tokenCount = 0}) {
         httpStatusCode: 409
       }, e);
   }
+
+  /* Note: An `openTokenBatch` record must only be added *after* a record
+  is inserted into `tokenBatch` collection *first*. This this ensures that if
+  we find a record in `openTokenBatch` that references a record that does not
+  exist in `tokenBatch`, it can *only* be because the `tokenBatch` record has
+  auto-expired, which means we can safely delete the reference to it in
+  `openTokenBatch`. Here, we also ignore the returned record and, if an error
+  occurs, we accept that the just created record in `tokenBatch` will not ever
+  be used, but will eventually expire and get cleaned up. */
+  await _createOpenBatchReference({internalId, batchId: id});
+
   return record;
 }
 
@@ -619,14 +637,52 @@ async function _getOpenBatch({internalId, batchVersion, tokenCount}) {
 }
 
 async function _getUnfilledBatch({internalId, batchVersion}) {
-  const query = {
-    'tokenBatch.internalId': internalId,
-    'tokenBatch.batchVersion': batchVersion.id,
-    'tokenBatch.remainingTokenCount': {$gt: 0}
-  };
-  const projection = {_id: 0};
+  /* Note: Use the `openTokenBatch` collection to find a reference to an
+  unfilled batch first. This indirection ensures fast look ups, as we need to
+  query without `tokenBatch.id` to find an open batch, which means we must
+  shard the references using `internalId` ... and we can't shard the batches
+  themselves using `internalId` because hot path queries there will instead
+  only have `tokenBatch.id`, not `internalId`. Queries that don't include
+  the shard key will be very inefficient so we avoid this by using two separate
+  collections that shard differently but ensure the shard key will be present
+  in the hot path queries. See the note where the indexes are created above for
+  more details. */
+
+  // optimize for the common case where the `batchVersion.id` will match;
+  // but handle the case where the batch version has changed and we need to
+  // remove references to batches that should no longer be filled because of
+  // the new version
   const collection = database.collections['tokenization-tokenBatch'];
-  return collection.findOne(query, {projection});
+  while(true) {
+    // should be a fast query on `openTokenBatch` collection using `internalId`
+    // shard key
+    const referenceRecord = await _getOpenBatchReference({internalId});
+    if(referenceRecord === null) {
+      // no open batches
+      return null;
+    }
+
+    // get batch via `batchId` in reference (should be a fast query on
+    // `tokenBatch` collection using `tokenBatch.id` shard key)
+    const {batchId} = referenceRecord;
+    const query = {'tokenBatch.id': batchId};
+    const projection = {_id: 0};
+    const record = await collection.findOne(query, {projection});
+    if(!record ||
+      record.tokenBatch.batchVersion !== batchVersion.id ||
+      record.tokenBatch.remainingTokenCount === 0) {
+      // either:
+      // no matching record (it must have expired),
+      // matching record but version is old (do not continue to fill it),
+      // or no tokens left to issue in the batch... in all cases, remove the
+      // open batch reference and try again
+      await _removeOpenBatchReference({internalId, batchId});
+      continue;
+    }
+
+    // found an acceptable batch, return it
+    return record;
+  }
 }
 
 async function _getBatch({id}) {
@@ -648,10 +704,11 @@ async function _getBatch({id}) {
 }
 
 async function _claimTokens({tokenBatch, tokenCount}) {
+  const {internalId, id: batchId} = tokenBatch;
   const target = Math.min(tokenBatch.remainingTokenCount, tokenCount);
   const query = {
-    'tokenBatch.internalId': tokenBatch.internalId,
-    'tokenBatch.id': tokenBatch.id,
+    'tokenBatch.internalId': internalId,
+    'tokenBatch.id': batchId,
     'tokenBatch.remainingTokenCount': tokenBatch.remainingTokenCount
   };
   const newRemainingTokenCount = tokenBatch.remainingTokenCount - target;
@@ -666,10 +723,53 @@ async function _claimTokens({tokenBatch, tokenCount}) {
     // could not claim tokens
     return {tokenBatch, claimedTokenCount: 0};
   }
-  // tokens claimed
+  // tokens claimed, delete open batch reference if none remain
+  if(newRemainingTokenCount === 0) {
+    await _removeOpenBatchReference({internalId, batchId});
+  }
+
+  // return updated batch info
   const batch = {...tokenBatch, remainingTokenCount: newRemainingTokenCount};
   const startIndex = tokenBatch.maxTokenCount - tokenBatch.remainingTokenCount;
   return {tokenBatch: batch, startIndex, claimedTokenCount: target};
+}
+
+async function _createOpenBatchReference({internalId, batchId}) {
+  const now = Date.now();
+  const collection = database.collections['tokenization-openTokenBatch'];
+  const meta = {created: now, updated: now};
+  let record = {
+    meta,
+    internalId,
+    batchId
+  };
+  try {
+    const result = await collection.insertOne(record, database.writeOptions);
+    record = result.ops[0];
+  } catch(e) {
+    if(!database.isDuplicateError(e)) {
+      throw e;
+    }
+    throw new BedrockError(
+      'Duplicate open token batch.',
+      'DuplicateError', {
+        public: true,
+        httpStatusCode: 409
+      }, e);
+  }
+  return record;
+}
+
+async function _getOpenBatchReference({internalId}) {
+  const query = {internalId};
+  const projection = {_id: 0};
+  const collection = database.collections['tokenization-openTokenBatch'];
+  return collection.findOne(query, {projection});
+}
+
+async function _removeOpenBatchReference({internalId, batchId}) {
+  const collection = database.collections['tokenization-openTokenBatch'];
+  await collection.deleteOne({internalId, batchId}, database.writeOptions);
 }
 
 async function _upsertPairwiseToken({internalId, requester}) {

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -45,8 +45,8 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
   ]);
 
   await promisify(database.createIndexes)([{
-    /* Note: The `tokenBatch` collection is sharded by `tokenBatch.id`. This
-    collection stores the batch information and is separate from the
+    /* Note: The `tokenBatch` collection should be sharded by `tokenBatch.id`.
+    This collection stores the batch information and is separate from the
     `openTokenBatch` collection that just tracks which batches are unfilled
     (more tokens can still be issued from them). These collections are
     independent because they require different sharding characteristics to

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -654,7 +654,7 @@ async function _getUnfilledBatch({internalId, batchVersion}) {
     // should be a fast query on `openTokenBatch` collection using `internalId`
     // shard key
     const referenceRecord = await _getOpenBatchReference({internalId});
-    if(referenceRecord === null) {
+    if(!referenceRecord) {
       // no open batches
       return null;
     }

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -706,6 +706,12 @@ async function _claimTokens({tokenBatch, tokenCount}) {
   const query = {
     'tokenBatch.internalId': internalId,
     'tokenBatch.id': batchId,
+    // we must include the existing `remainingTokenCount` as a monotonically
+    // decreasing counter to ensure that the record hasn't changed since
+    // we read it (attempts can be made to concurrently issue tokens from
+    // the same batch and we must protect against that); this is essentially
+    // a proxy for a "version" of the record without needing the additional
+    // storage space for a "version" or "sequence" number
     'tokenBatch.remainingTokenCount': tokenBatch.remainingTokenCount
   };
   const newRemainingTokenCount = tokenBatch.remainingTokenCount - target;

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-tokenization",
   "dependencies": {
-    "assert-plus": "^1.0.0",
     "@digitalbazaar/bitstring": "^1.0.0",
+    "@digitalbazaar/cborld": "^1.0.0",
+    "assert-plus": "^1.0.0",
+    "base58-universal": "^1.0.0",
     "bnid": "^2.0.0",
     "canonicalize": "^1.0.1",
     "did-io": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "did-io": "^0.8.2",
     "did-method-key": "^0.6.1",
     "isomorphic-webcrypto": "^2.3.6",
+    "lru-cache": "^6.0.0",
     "minimal-cipher": "^1.0.0",
     "p-limit": "^3.0.1",
     "pako": "^1.0.11"

--- a/test/mocha/20-tokens.js
+++ b/test/mocha/20-tokens.js
@@ -116,23 +116,6 @@ describe('Tokens', function() {
       err.message.should.equal('"attributes" must be a Uint8Array.');
     }
   });
-  it('should throw error if attributes.length is greater than MAX_AAD_SIZE',
-    async function() {
-      const tokenCount = 5;
-      const internalId = 'aM6pup9s6XTaYThoUxThuEx';
-      const attributes = Uint8Array.from(new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]));
-      let err;
-      let result;
-      try {
-        result = await tokens.create({internalId, attributes, tokenCount});
-      } catch(e) {
-        err = e;
-      }
-      should.not.exist(result);
-      should.exist(err);
-      err.name.should.equal('RangeError');
-      err.message.should.equal('"attributes" maximum size is 8 bytes.');
-    });
   it('should throw error if token does not exist in database',
     async function() {
       const tokenCount = 1;
@@ -362,8 +345,8 @@ describe('Tokens', function() {
       const {tokens: tks} = await tokens.create(
         {internalId, attributes, tokenCount});
       const token = tks[0];
-      // change wrapped value by altering its first index
-      token[26] = 0;
+      // change wrapped value by incrementing its first index
+      token[65] = (token[65] + 1) & 0xFF;
       try {
         result = await tokens.resolve({requester, token});
       } catch(e) {


### PR DESCRIPTION
So this is ready based on the current version of cborld. We're expecting more changes to that library so we'll need to account for those when they land. This will most likely require changes to the test suite and `documentLoader.js`.

@JoshDunnDev, @mandyvenables -- It may help for you guys to take a look at this as well to note the cborld usage.