### PR TITLE
Simplify resolution list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-tokenization ChangeLog
 
+## 3.0.0 - 2020-09-xx
+
+### Changed
+- **BREAKING**: Changed format for storing token resolutions.
+
 ## 2.0.0 - 2020-08-24
 
 ### Changed

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -244,16 +244,16 @@ export async function resolve({requester, token}) {
       buffer: await Bitstring.decodeBits({encoded})
     });
 
-    // find resolution entry for `requester`
+    // find resolution list for `requester`
     const encodedRequester = base64url.encode(requester);
-    let entry = resolution[encodedRequester];
+    let requesterList = resolution[encodedRequester];
 
     // see if token is already resolved
     if(resolvedList.get(index)) {
       // token already resolved, see if requester matches
-      if(entry) {
+      if(requesterList) {
         const bs = new Bitstring({
-          buffer: await Bitstring.decodeBits({encoded: entry.list})
+          buffer: await Bitstring.decodeBits({encoded: requesterList})
         });
         if(bs.get(index)) {
           // token resolved for same requester, return pairwise token
@@ -280,16 +280,15 @@ export async function resolve({requester, token}) {
 
     // update requester's resolution info for the token batch
     let bs;
-    if(entry) {
+    if(requesterList) {
       bs = new Bitstring({
-        buffer: await Bitstring.decodeBits({encoded: entry.list})
+        buffer: await Bitstring.decodeBits({encoded: requesterList})
       });
     } else {
       bs = new Bitstring({length: 256});
-      entry = resolution[resolution.length] = {requester};
     }
     bs.set(index, true);
-    entry.list = await bs.encodeBits();
+    requesterList = await bs.encodeBits();
 
     // mark token as resolved
     resolvedList.set(index, true);
@@ -306,7 +305,7 @@ export async function resolve({requester, token}) {
       $set: {
         'meta.updated': Date.now(),
         'tokenBatch.resolvedList': await resolvedList.encodeBits(),
-        [`tokenBatch.resolution.${encodedRequester}`]: entry
+        [`tokenBatch.resolution.${encodedRequester}`]: requesterList
       }
     }, database.writeOptions);
     if(result.result.n === 0) {


### PR DESCRIPTION
Do not store both the encoded/unencoded requester ID (just store the encoded ID needed for the map).