### PR TITLE
Implement recipientChain param for documents.register().

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -111,7 +111,6 @@ export async function register({
 } = {}) {
   assert.optionalArrayOfObject(recipients, 'recipients');
   assert.optionalArrayOfArray(recipientChain, 'recipientChain');
-
   if(recipientChain) {
     if(recipients) {
       throw new TypeError(

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -159,7 +159,7 @@ export async function register({
     }
 
     // 5. Encrypt the document for storage.
-    const jwe = await encrypt({document, recipients, recipientChain});
+    const jwe = await _encrypt({document, recipients, recipientChain});
 
     // 6. Insert the encrypted document.
     try {
@@ -195,7 +195,7 @@ export async function register({
  *
  * @returns {Promise<object>} Resolves with the JWE, the result of encryption.
  */
-export async function encrypt({document, recipients, recipientChain}) {
+export async function _encrypt({document, recipients, recipientChain}) {
   const keyResolver = createKeyResolver();
   const cipher = new Cipher();
 

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -118,7 +118,7 @@ export async function register({
         'Only one of "recipients" or "recipientChain" is allowed.');
     }
     if(recipientChain.length === 0) {
-      throw new TypeError('"recipientChain" cannot be empty.');
+      throw new TypeError('"recipientChain" must be a non-empty array.');
     }
 
     recipientChain.forEach(e => assert.arrayOfObject(e));
@@ -207,14 +207,6 @@ export async function encrypt({document, recipients, recipientChain}) {
 
   let result = document;
   for(const recipientSet of recipientChain) {
-    if(!(recipientSet && recipientSet.length > 0)) {
-      throw new BedrockError(
-        'Invalid recipient',
-        'TypeError', {
-          public: true,
-          httpStatusCode: 400
-        });
-    }
     result = await cipher.encryptObject({
       obj: result, recipients: recipientSet, keyResolver
     });

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -79,9 +79,9 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
  * @param {object} options.document - The document to register.
  *
  * Note: Either `recipients` or `recipientChain` is required.
- * @param {Array<object>} [options.recipients] - A list of recipients identified by
- *   key agreement key ids. An ephemeral ECDH key will be generated and used to
- *   derive shared KEKs that will wrap a randomly generated CEK. The CEK will
+ * @param {Array<object>} [options.recipients] - A list of recipients identified
+ *   by key agreement key ids. An ephemeral ECDH key will be generated and used
+ *   to derive shared KEKs that will wrap a randomly generated CEK. The CEK will
  *   be used to encrypt the document. Each recipient in the `recipients` array
  *   will be capable of decrypting the document.
  * @param {Array<Array<object>>} [options.recipientChain] - Same as `recipients`
@@ -117,6 +117,10 @@ export async function register({
       throw new TypeError(
         'Only one of "recipients" or "recipientChain" is allowed.');
     }
+    if(recipientChain.length === 0) {
+      throw new TypeError('"recipientChain" cannot be empty.');
+    }
+
     recipientChain.forEach(e => assert.arrayOfObject(e));
   } else if(!recipients) {
     throw new TypeError('"recipients" or "recipientChain" is required.');

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -249,6 +249,33 @@ export async function _generateInternalId() {
 }
 
 /**
+ * Retrieves the encrypted registration for an internalId.
+ *
+ * @param {object} options - Options to use.
+ * @param {string} options.internalId - The internalId to use.
+ *
+ * @returns {Promise<object>} Resolves with the registration JWE.
+ */
+export async function getRegistration({internalId}) {
+  const query = {
+    'registration.internalId': internalId
+  };
+
+  const collection = database.collections['tokenization-registration'];
+  const record = await collection.findOne(query);
+  if(!record) {
+    const details = {
+      httpStatusCode: 404,
+      public: true
+    };
+    throw new BedrockError(
+      'Document not found.',
+      'NotFoundError', details);
+  }
+  return record;
+}
+
+/**
  * Tokenizes the registration information.
  *
  * @param {object} options - Options to use.
@@ -298,6 +325,7 @@ export async function _getRegistrationRecord(
     'registration.externalIdHash': externalIdHash,
     'registration.documentHash': documentHash
   };
+
   const projection = {_id: 0};
   const collection = database.collections['tokenization-registration'];
   const record = await collection.findOne(query, {projection});

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -76,11 +76,18 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
  * @param {string} options.externalId - An application-specific string that
  *   unambiguously identifies a particular entity to the application.
  * @param {object} options.document - The document to register.
- * @param {array} options.recipients - A list of recipients identified by
+ *
+ * Note: Either `recipients` or `recipientChain` is required.
+ * @param {string[]} [options.recipients] - A list of recipients identified by
  *   key agreement keys. An ephemeral ECDH key will be generated and used to
  *   derive shared KEKs that will wrap a randomly generated CEK. The CEK will
  *   be used to encrypt the document. Each recipient in the `recipients` array
  *   will be capable of decrypting the document.
+ * @param {Array<Array<string>>} [options.recipientChain] - Same as `recipients`
+ *   param above, but contains _nested arrays_ of key agreement keys.
+ *   Use this if you want to first encrypt with one set of recipients, then
+ *   encrypt the resulting JWE with the next array of recipients, and so on.
+ *
  * @param {number} options.ttl - The number of milliseconds until the
  *   document should expire.
  * @param {string} [options.creator] - Optional identifier for the creator
@@ -98,7 +105,7 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
  * @returns {Promise<object>} An object with the registration record.
  */
 export async function register({
-  internalId, externalId, document, recipients, ttl, creator,
+  internalId, externalId, document, recipients, recipientChain, ttl, creator,
   tokenizer, externalIdHash, documentHash, creatorHash, newRegistration
 } = {}) {
   // 1. & 2. Get tokenizer and hmac hashed fields if they were not passed in.
@@ -136,10 +143,7 @@ export async function register({
     }
 
     // 5. Encrypt the document for storage.
-    const cipher = new Cipher();
-    const obj = document;
-    const keyResolver = createKeyResolver();
-    const jwe = await cipher.encryptObject({obj, recipients, keyResolver});
+    const jwe = await encrypt({document, recipients, recipientChain});
 
     // 6. Insert the encrypted document.
     try {
@@ -162,6 +166,56 @@ export async function register({
       continue;
     }
   }
+}
+
+/**
+ * Encrypts the document either once (with the given recipients) or recursively
+ * in a chain (using the recipientChain).
+ *
+ * @param {object} options - Options hashmap.
+ * @param {object} options.document - The document to register.
+ * @param {Array<string>} recipients - See `register()` docstring.
+ * @param {Array<Array<string>>} recipientChain - See `register()` docstring.
+ *
+ * @returns {Promise<object>} Resolves with the JWE, the result of encryption.
+ */
+export async function encrypt({document, recipients, recipientChain}) {
+  if(!(recipients || recipientChain)) {
+    throw new BedrockError(
+      'Encryption recipients or recipientChain is required.',
+      'ValidationError', {
+        public: true,
+        httpStatusCode: 400
+      });
+  }
+
+  const obj = document;
+  const keyResolver = createKeyResolver();
+  const cipher = new Cipher();
+
+  if(recipientChain) {
+    if(!Array.isArray(recipientChain)) {
+      throw new BedrockError(
+        '"recipientChain" must be an array.',
+        'ValidationError', {
+          public: true,
+          httpStatusCode: 400
+        });
+    }
+
+    const [currentRecipients, ...remainingRecipientChain] = recipientChain;
+    const jwe = await cipher.encryptObject({
+      obj, recipients: currentRecipients, keyResolver
+    });
+
+    if(remainingRecipientChain) {
+      return encrypt({document: jwe, recipientChain: remainingRecipientChain});
+    }
+
+    return jwe;
+  }
+
+  return cipher.encryptObject({obj, recipients, keyResolver});
 }
 
 /**

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -111,7 +111,7 @@ export async function register({
   if(!(recipients || recipientChain)) {
     throw new BedrockError(
       'Encryption recipients or recipientChain is required.',
-      'ValidationError', {
+      'TypeError', {
         public: true,
         httpStatusCode: 400
       });
@@ -119,15 +119,24 @@ export async function register({
   if(recipients && recipientChain) {
     throw new BedrockError(
       'Either recipients or recipientChain is required, not both.',
-      'ValidationError', {
+      'TypeError', {
         public: true,
         httpStatusCode: 400
       });
   }
-  if(recipientChain && !Array.isArray(recipientChain)) {
+  if(recipients && !(Array.isArray(recipients) && recipients.length > 0)) {
     throw new BedrockError(
-      '"recipientChain" must be an array.',
-      'ValidationError', {
+      '"recipients" must be a non-empty array.',
+      'TypeError', {
+        public: true,
+        httpStatusCode: 400
+      });
+  }
+  if(recipientChain &&
+     !(Array.isArray(recipientChain) && recipientChain.length > 0)) {
+    throw new BedrockError(
+      '"recipientChain" must be a non-empty array.',
+      'TypeError', {
         public: true,
         httpStatusCode: 400
       });
@@ -214,6 +223,14 @@ export async function encrypt({document, recipients, recipientChain}) {
 
   let result = document;
   for(const recipientSet of recipientChain) {
+    if(!(recipientSet && recipientSet.length > 0)) {
+      throw new BedrockError(
+        'Invalid recipient',
+        'TypeError', {
+          public: true,
+          httpStatusCode: 400
+        });
+    }
     result = await cipher.encryptObject({
       obj: result, recipients: recipientSet, keyResolver
     });

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -79,12 +79,12 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
  * @param {object} options.document - The document to register.
  *
  * Note: Either `recipients` or `recipientChain` is required.
- * @param {string[]} [options.recipients] - A list of recipients identified by
+ * @param {Array<object>} [options.recipients] - A list of recipients identified by
  *   key agreement key ids. An ephemeral ECDH key will be generated and used to
  *   derive shared KEKs that will wrap a randomly generated CEK. The CEK will
  *   be used to encrypt the document. Each recipient in the `recipients` array
  *   will be capable of decrypting the document.
- * @param {Array<Array<string>>} [options.recipientChain] - Same as `recipients`
+ * @param {Array<Array<object>>} [options.recipientChain] - Same as `recipients`
  *   param above, but contains _nested arrays_ of key agreement key ids.
  *   Use this if you want to first encrypt with one set of recipients, then
  *   encrypt the resulting JWE with the next array of recipients, and so on.
@@ -188,8 +188,8 @@ export async function register({
  *
  * @param {object} options - Options hashmap.
  * @param {object} options.document - The document to register.
- * @param {Array<string>} recipients - See `register()` docstring.
- * @param {Array<Array<string>>} recipientChain - See `register()` docstring.
+ * @param {Array<object>} recipients - See `register()` docstring.
+ * @param {Array<Array<object>>} recipientChain - See `register()` docstring.
  *
  * @returns {Promise<object>} Resolves with the JWE, the result of encryption.
  */

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -119,6 +119,9 @@ export async function register({
     if(recipientChain.length === 0) {
       throw new TypeError('"recipientChain" must be a non-empty array.');
     }
+    if(recipientChain.length === 0) {
+      throw new TypeError('"recipientChain" must be a non-empty array.');
+    }
     recipientChain.forEach(e => assert.arrayOfObject(e));
   } else if(!recipients) {
     throw new TypeError('"recipients" or "recipientChain" is required.');

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -119,7 +119,6 @@ export async function register({
     if(recipientChain.length === 0) {
       throw new TypeError('"recipientChain" must be a non-empty array.');
     }
-
     recipientChain.forEach(e => assert.arrayOfObject(e));
   } else if(!recipients) {
     throw new TypeError('"recipients" or "recipientChain" is required.');

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -255,13 +255,16 @@ export async function getRegistration({internalId} = {}) {
  * @param {object} options - Options to use.
  * @param {object} [options.tokenizer] - Optional tokenizer to use.
  * @param {string} options.externalId - The external ID to use.
- * @param {string} options.document - The registration document.
+ * @param {object} options.document - The registration document.
  * @param {string} [options.creator] - An optional registration creator.
  *
  * @returns {Promise<object>} The tokenized registration information.
  */
 export async function _tokenizeRegistration(
   {tokenizer, externalId, document, creator} = {}) {
+  assert.string(externalId, 'externalId');
+  assert.object(document, 'document');
+
   // 1. Get the current tokenizer and its HMAC API.
   if(!tokenizer) {
     tokenizer = await tokenizers.getCurrent();

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -79,12 +79,12 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
  *
  * Note: Either `recipients` or `recipientChain` is required.
  * @param {string[]} [options.recipients] - A list of recipients identified by
- *   key agreement keys. An ephemeral ECDH key will be generated and used to
+ *   key agreement key ids. An ephemeral ECDH key will be generated and used to
  *   derive shared KEKs that will wrap a randomly generated CEK. The CEK will
  *   be used to encrypt the document. Each recipient in the `recipients` array
  *   will be capable of decrypting the document.
  * @param {Array<Array<string>>} [options.recipientChain] - Same as `recipients`
- *   param above, but contains _nested arrays_ of key agreement keys.
+ *   param above, but contains _nested arrays_ of key agreement key ids.
  *   Use this if you want to first encrypt with one set of recipients, then
  *   encrypt the resulting JWE with the next array of recipients, and so on.
  *
@@ -169,8 +169,6 @@ export async function register({
 
     // 5. Encrypt the document for storage.
     const jwe = await encrypt({document, recipients, recipientChain});
-
-    console.log('JWE:', jwe);
 
     // 6. Insert the encrypted document.
     try {

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -116,10 +116,17 @@ export async function register({
         httpStatusCode: 400
       });
   }
-
   if(recipients && recipientChain) {
     throw new BedrockError(
       'Either recipients or recipientChain is required, not both.',
+      'ValidationError', {
+        public: true,
+        httpStatusCode: 400
+      });
+  }
+  if(recipientChain && !Array.isArray(recipientChain)) {
+    throw new BedrockError(
+      '"recipientChain" must be an array.',
       'ValidationError', {
         public: true,
         httpStatusCode: 400
@@ -163,6 +170,8 @@ export async function register({
     // 5. Encrypt the document for storage.
     const jwe = await encrypt({document, recipients, recipientChain});
 
+    console.log('JWE:', jwe);
+
     // 6. Insert the encrypted document.
     try {
       const record = await _insertRegistration({
@@ -198,33 +207,21 @@ export async function register({
  * @returns {Promise<object>} Resolves with the JWE, the result of encryption.
  */
 export async function encrypt({document, recipients, recipientChain}) {
-  const obj = document;
   const keyResolver = createKeyResolver();
   const cipher = new Cipher();
 
-  if(recipientChain) {
-    if(!Array.isArray(recipientChain)) {
-      throw new BedrockError(
-        '"recipientChain" must be an array.',
-        'ValidationError', {
-          public: true,
-          httpStatusCode: 400
-        });
-    }
-
-    const [currentRecipients, ...remainingRecipientChain] = recipientChain;
-    const jwe = await cipher.encryptObject({
-      obj, recipients: currentRecipients, keyResolver
-    });
-
-    if(remainingRecipientChain.length > 0) {
-      return encrypt({document: jwe, recipientChain: remainingRecipientChain});
-    }
-
-    return jwe;
+  if(recipients) {
+    recipientChain = [recipients];
   }
 
-  return cipher.encryptObject({obj, recipients, keyResolver});
+  let result = document;
+  for(const recipientSet of recipientChain) {
+    result = await cipher.encryptObject({
+      obj: result, recipients: recipientSet, keyResolver
+    });
+  }
+
+  return result;
 }
 
 /**

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -208,7 +208,7 @@ export async function encrypt({document, recipients, recipientChain}) {
       obj, recipients: currentRecipients, keyResolver
     });
 
-    if(remainingRecipientChain) {
+    if(remainingRecipientChain.length > 0) {
       return encrypt({document: jwe, recipientChain: remainingRecipientChain});
     }
 

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -108,6 +108,24 @@ export async function register({
   internalId, externalId, document, recipients, recipientChain, ttl, creator,
   tokenizer, externalIdHash, documentHash, creatorHash, newRegistration
 } = {}) {
+  if(!(recipients || recipientChain)) {
+    throw new BedrockError(
+      'Encryption recipients or recipientChain is required.',
+      'ValidationError', {
+        public: true,
+        httpStatusCode: 400
+      });
+  }
+
+  if(recipients && recipientChain) {
+    throw new BedrockError(
+      'Either recipients or recipientChain is required, not both.',
+      'ValidationError', {
+        public: true,
+        httpStatusCode: 400
+      });
+  }
+
   // 1. & 2. Get tokenizer and hmac hashed fields if they were not passed in.
   if(!tokenizer) {
     tokenizer = await tokenizers.getCurrent();
@@ -180,15 +198,6 @@ export async function register({
  * @returns {Promise<object>} Resolves with the JWE, the result of encryption.
  */
 export async function encrypt({document, recipients, recipientChain}) {
-  if(!(recipients || recipientChain)) {
-    throw new BedrockError(
-      'Encryption recipients or recipientChain is required.',
-      'ValidationError', {
-        public: true,
-        httpStatusCode: 400
-      });
-  }
-
   const obj = document;
   const keyResolver = createKeyResolver();
   const cipher = new Cipher();

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
+import assert from 'assert-plus';
 import * as base64url from 'base64url-universal';
 import * as bedrock from 'bedrock';
 import * as database from 'bedrock-mongodb';
@@ -108,38 +109,17 @@ export async function register({
   internalId, externalId, document, recipients, recipientChain, ttl, creator,
   tokenizer, externalIdHash, documentHash, creatorHash, newRegistration
 } = {}) {
-  if(!(recipients || recipientChain)) {
-    throw new BedrockError(
-      'Encryption recipients or recipientChain is required.',
-      'TypeError', {
-        public: true,
-        httpStatusCode: 400
-      });
-  }
-  if(recipients && recipientChain) {
-    throw new BedrockError(
-      'Either recipients or recipientChain is required, not both.',
-      'TypeError', {
-        public: true,
-        httpStatusCode: 400
-      });
-  }
-  if(recipients && !(Array.isArray(recipients) && recipients.length > 0)) {
-    throw new BedrockError(
-      '"recipients" must be a non-empty array.',
-      'TypeError', {
-        public: true,
-        httpStatusCode: 400
-      });
-  }
-  if(recipientChain &&
-     !(Array.isArray(recipientChain) && recipientChain.length > 0)) {
-    throw new BedrockError(
-      '"recipientChain" must be a non-empty array.',
-      'TypeError', {
-        public: true,
-        httpStatusCode: 400
-      });
+  assert.optionalArrayOfObject(recipients, 'recipients');
+  assert.optionalArrayOfArray(recipientChain, 'recipientChain');
+
+  if(recipientChain) {
+    if(recipients) {
+      throw new TypeError(
+        'Only one of "recipients" or "recipientChain" is allowed.');
+    }
+    recipientChain.forEach(e => assert.arrayOfObject(e));
+  } else if(!recipients) {
+    throw new TypeError('"recipients" or "recipientChain" is required.');
   }
 
   // 1. & 2. Get tokenizer and hmac hashed fields if they were not passed in.

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -236,7 +236,7 @@ export async function _generateInternalId() {
  *
  * @returns {Promise<object>} Resolves with the registration JWE.
  */
-export async function getRegistration({internalId}) {
+export async function getRegistration({internalId} = {}) {
   const query = {
     'registration.internalId': internalId
   };

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -130,7 +130,7 @@ export async function registerDocumentAndCreate(
   and the same database is used for both tokens and registrations, a case
   where tokens can be created but registrations cannot is predicted to be
   rare. Care should still be taken to ensure these scenarios do not occur,
-  as they will result in producing unusuable tokens that take up space in
+  as they will result in producing unusable tokens that take up space in
   the database. Care should also be taken to ensure that an attacker cannot
   exploit this outcome.
 
@@ -327,9 +327,9 @@ export async function create(
  * resolution will be returned again.
  *
  * @param {object} options - Options to use.
- * @param {string} options.requester - The a string that unambiguously
+ * @param {string} options.requester - The string that unambiguously
  *   identifies the party requesting token resolution.
- * @param {string} options.token - The token to resolve.
+ * @param {Buffer} options.token - Decoded scoped token to resolve.
  *
  * @returns {object} An object containing the Uint8Array `pairwiseToken`.
  */

--- a/test/mocha/10-documents.js
+++ b/test/mocha/10-documents.js
@@ -12,8 +12,8 @@ const recipients = [
   }
 ];
 
-describe('Documents', function() {
-  it('should register a document without creator', async function() {
+describe('documents.register()', () => {
+  it('should register a document without creator', async () => {
     const result = await documents.register({
       externalId: 'did:test:register',
       document: {},
@@ -23,7 +23,7 @@ describe('Documents', function() {
     isRegistration(result);
   });
 
-  it.skip('should register a document with creator', async function() {
+  it.skip('should register a document with creator', async () => {
     const result = await documents.register({
       externalId: 'did:test:register:with:data',
       document: {},
@@ -34,7 +34,7 @@ describe('Documents', function() {
     isRegistration(result);
   });
 
-  it.skip('should delete a document with an expired ttl', async function() {
+  it.skip('should delete a document with an expired ttl', async () => {
     const result = await documents.register({
       externalId: 'did:test:register:with:small:ttl',
       document: {},
@@ -43,4 +43,8 @@ describe('Documents', function() {
     });
     isRegistration(result);
   });
+});
+
+describe('documents.encrypt()', () => {
+  it('should encrypt a document with recipients');
 });

--- a/test/mocha/10-documents.js
+++ b/test/mocha/10-documents.js
@@ -15,6 +15,43 @@ const recipients = [
   }
 ];
 
+const key1 = new X25519KeyPair({
+  id: 'did:key:z6MkgDEDniwkugeRADbi5CmHFB2eFdFKh6gSCYHFUeHXaV2x' +
+    '#z6LScXou54NfzNThVwG1aF85TCuFbVPmKuKspufF7eVmHW7G',
+  controller: 'did:key:z6MkgDEDniwkugeRADbi5CmHFB2eFdFKh6gSCYHFUeHXaV2x',
+  type: 'X25519KeyAgreementKey2019',
+  publicKeyBase58: 'rdjYkZotujxQYtF3bc88cgmkLredJ9iwvwZdBrEa8LW',
+  privateKeyBase58: '4HKArAGZaGzwutAEjsbTSjbKDLrQJAP3zLPoZQtHxeuh'
+});
+
+const key2 = new X25519KeyPair({
+  id: 'did:key:z6MkrefS4sDAGNBdo7CeXKh52sBfK94NGMANfHKfbYpvPz8S' +
+    '#z6LScKCBLkDApcTvYPbjQi6EDKgpYwWiM9Ppd6X1PbjXF2dg',
+  controller: 'did:key:z6MkrefS4sDAGNBdo7CeXKh52sBfK94NGMANfHKfbYpvPz8S',
+  type: 'X25519KeyAgreementKey2019',
+  publicKeyBase58: 'e21pSQJj9kBT1Dxt4aGtjULhnybeYDfk7oKu95zXerv',
+  privateKeyBase58: 'bcB3uZng7RPz7VSEJSid54cyiU2STGHk4Ub91VEenPP'
+});
+
+describe('documents.getRegistration()', () => {
+  it('should retrieve a registration for an internalId', async () => {
+    const recipients = [
+      {header: {kid: key1.id, alg: 'ECDH-ES+A256KW'}}
+    ];
+    const document = {example: 'document'};
+    const {registration: {jwe: encryptedRegistration, internalId}} =
+      await documents.register({
+        creator: 'someCreatorId',
+        document,
+        recipients,
+        ttl: 30000
+      });
+
+    const {registration: {jwe}} = await documents.getRegistration({internalId});
+    jwe.should.eql(encryptedRegistration);
+  });
+});
+
 describe('documents.register()', () => {
   it('should register a document without creator', async () => {
     const result = await documents.register({
@@ -79,24 +116,6 @@ describe('documents.register()', () => {
 });
 
 describe('documents.encrypt()', () => {
-  const key1 = new X25519KeyPair({
-    id: 'did:key:z6MkgDEDniwkugeRADbi5CmHFB2eFdFKh6gSCYHFUeHXaV2x' +
-      '#z6LScXou54NfzNThVwG1aF85TCuFbVPmKuKspufF7eVmHW7G',
-    controller: 'did:key:z6MkgDEDniwkugeRADbi5CmHFB2eFdFKh6gSCYHFUeHXaV2x',
-    type: 'X25519KeyAgreementKey2019',
-    publicKeyBase58: 'rdjYkZotujxQYtF3bc88cgmkLredJ9iwvwZdBrEa8LW',
-    privateKeyBase58: '4HKArAGZaGzwutAEjsbTSjbKDLrQJAP3zLPoZQtHxeuh'
-  });
-
-  const key2 = new X25519KeyPair({
-    id: 'did:key:z6MkrefS4sDAGNBdo7CeXKh52sBfK94NGMANfHKfbYpvPz8S' +
-      '#z6LScKCBLkDApcTvYPbjQi6EDKgpYwWiM9Ppd6X1PbjXF2dg',
-    controller: 'did:key:z6MkrefS4sDAGNBdo7CeXKh52sBfK94NGMANfHKfbYpvPz8S',
-    type: 'X25519KeyAgreementKey2019',
-    publicKeyBase58: 'e21pSQJj9kBT1Dxt4aGtjULhnybeYDfk7oKu95zXerv',
-    privateKeyBase58: 'bcB3uZng7RPz7VSEJSid54cyiU2STGHk4Ub91VEenPP'
-  });
-
   it('should encrypt a document with recipients', async () => {
     const recipients = [
       {header: {kid: key1.id, alg: 'ECDH-ES+A256KW'}},

--- a/test/mocha/10-documents.js
+++ b/test/mocha/10-documents.js
@@ -1,5 +1,8 @@
 const {requireUncached, isRegistration} = require('./helpers');
 const {documents} = requireUncached('bedrock-tokenization');
+const {X25519KeyPair} = require('x25519-key-pair');
+const {Cipher} = require('minimal-cipher');
+const cipher = new Cipher();
 
 // this is test data borrowed from minimal-cipher
 const recipients = [
@@ -46,5 +49,65 @@ describe('documents.register()', () => {
 });
 
 describe('documents.encrypt()', () => {
-  it('should encrypt a document with recipients');
+  const key1 = new X25519KeyPair({
+    id: 'did:key:z6MkgDEDniwkugeRADbi5CmHFB2eFdFKh6gSCYHFUeHXaV2x' +
+      '#z6LScXou54NfzNThVwG1aF85TCuFbVPmKuKspufF7eVmHW7G',
+    controller: 'did:key:z6MkgDEDniwkugeRADbi5CmHFB2eFdFKh6gSCYHFUeHXaV2x',
+    type: 'X25519KeyAgreementKey2019',
+    publicKeyBase58: 'rdjYkZotujxQYtF3bc88cgmkLredJ9iwvwZdBrEa8LW',
+    privateKeyBase58: '4HKArAGZaGzwutAEjsbTSjbKDLrQJAP3zLPoZQtHxeuh'
+  });
+
+  const key2 = new X25519KeyPair({
+    id: 'did:key:z6MkrefS4sDAGNBdo7CeXKh52sBfK94NGMANfHKfbYpvPz8S' +
+      '#z6LScKCBLkDApcTvYPbjQi6EDKgpYwWiM9Ppd6X1PbjXF2dg',
+    controller: 'did:key:z6MkrefS4sDAGNBdo7CeXKh52sBfK94NGMANfHKfbYpvPz8S',
+    type: 'X25519KeyAgreementKey2019',
+    publicKeyBase58: 'e21pSQJj9kBT1Dxt4aGtjULhnybeYDfk7oKu95zXerv',
+    privateKeyBase58: 'bcB3uZng7RPz7VSEJSid54cyiU2STGHk4Ub91VEenPP'
+  });
+
+  it('should encrypt a document with recipients', async () => {
+    const recipients = [
+      {header: {kid: key1.id, alg: 'ECDH-ES+A256KW'}},
+      {header: {kid: key2.id, alg: 'ECDH-ES+A256KW'}}
+    ];
+
+    const document = {example: 'document'};
+    const jwe = await documents.encrypt({document, recipients});
+
+    jwe.recipients.should.be.an('array');
+    jwe.recipients.length.should.equal(2);
+
+    const decrypted = await cipher.decryptObject({jwe, keyAgreementKey: key1});
+    decrypted.should.have.property('example', 'document');
+  });
+
+  it('should encrypt a document with a recipientChain', async () => {
+    const recipientChain = [
+      // first pass (inner jwe)
+      [{header: {kid: key1.id, alg: 'ECDH-ES+A256KW'}}],
+      // second pass (outer jwe)
+      [{header: {kid: key2.id, alg: 'ECDH-ES+A256KW'}}]
+    ];
+
+    const document = {example: 'document'};
+    const outerJwe = await documents.encrypt({document, recipientChain});
+
+    outerJwe.recipients.should.be.an('array');
+    outerJwe.recipients.length.should.equal(1);
+
+    const innerJwe = await cipher.decryptObject({
+      jwe: outerJwe, keyAgreementKey: key2
+    });
+
+    innerJwe.recipients.should.be.an('array');
+    innerJwe.recipients.length.should.equal(1);
+
+    const decrypted = await cipher.decryptObject({
+      jwe: innerJwe, keyAgreementKey: key1
+    });
+
+    decrypted.should.have.property('example', 'document');
+  });
 });

--- a/test/mocha/10-documents.js
+++ b/test/mocha/10-documents.js
@@ -39,8 +39,10 @@ describe('documents.getRegistration()', () => {
       {header: {kid: key1.id, alg: 'ECDH-ES+A256KW'}}
     ];
     const document = {example: 'document'};
+    const externalId = 'did:test:getRegistration';
     const {registration: {jwe: encryptedRegistration, internalId}} =
       await documents.register({
+        externalId,
         creator: 'someCreatorId',
         document,
         recipients,
@@ -65,10 +67,11 @@ describe('documents.register()', () => {
 
   it('should error when an empty recipients array is passed', async () => {
     const recipients = [];
+    const externalId = 'did:test:failure';
     const document = {example: 'document'};
     let err;
     try {
-      await documents.register({document, recipients});
+      await documents.register({externalId, document, recipients});
     } catch(e) {
       err = e;
     }
@@ -77,10 +80,11 @@ describe('documents.register()', () => {
 
   it('should error when an empty recipientChain array is passed', async () => {
     const recipientChain = [];
+    const externalId = 'did:test:failure';
     const document = {example: 'document'};
     let err;
     try {
-      await documents.register({document, recipientChain});
+      await documents.register({externalId, document, recipientChain});
     } catch(e) {
       err = e;
     }
@@ -89,32 +93,39 @@ describe('documents.register()', () => {
 
   it('should error when an empty recipientChain item is passed', async () => {
     const recipientChain = [[]];
+    const externalId = 'did:test:failure';
     const document = {example: 'document'};
     let err;
     try {
-      await documents.register({document, recipientChain});
+      await documents.register({externalId, document, recipientChain});
     } catch(e) {
       err = e;
     }
-    err.message.should.equal('"recipientChain" must be a non-empty array.');
+    err.message.should.equal('"recipients" must be a non-empty array.');
   });
 
-  it.skip('should register a document with creator', async () => {
+  it('should register a document with creator', async () => {
+    const recipients = [
+      {header: {kid: key1.id, alg: 'ECDH-ES+A256KW'}}
+    ];
     const result = await documents.register({
       externalId: 'did:test:register:with:data',
       document: {},
-      recipients: [],
+      recipients,
       ttl: 30000,
       creator: 'some_creator'
     });
     isRegistration(result);
   });
 
-  it.skip('should delete a document with an expired ttl', async () => {
+  it('should delete a document with an expired ttl', async () => {
+    const recipients = [
+      {header: {kid: key1.id, alg: 'ECDH-ES+A256KW'}}
+    ];
     const result = await documents.register({
       externalId: 'did:test:register:with:small:ttl',
       document: {},
-      recipients: [],
+      recipients,
       ttl: 1000
     });
     isRegistration(result);

--- a/test/mocha/10-documents.js
+++ b/test/mocha/10-documents.js
@@ -72,10 +72,7 @@ describe('documents.register()', () => {
     } catch(e) {
       err = e;
     }
-    err.name.should.equal('TypeError');
     err.message.should.equal('"recipients" must be a non-empty array.');
-    err.should.have.property('details');
-    err.details.should.have.property('httpStatusCode', 400);
   });
 
   it('should error when an empty recipientChain array is passed', async () => {
@@ -87,10 +84,19 @@ describe('documents.register()', () => {
     } catch(e) {
       err = e;
     }
-    err.name.should.equal('TypeError');
     err.message.should.equal('"recipientChain" must be a non-empty array.');
-    err.should.have.property('details');
-    err.details.should.have.property('httpStatusCode', 400);
+  });
+
+  it('should error when an empty recipientChain item is passed', async () => {
+    const recipientChain = [[]];
+    const document = {example: 'document'};
+    let err;
+    try {
+      await documents.register({document, recipientChain});
+    } catch(e) {
+      err = e;
+    }
+    err.message.should.equal('"recipientChain" must be a non-empty array.');
   });
 
   it.skip('should register a document with creator', async () => {

--- a/test/mocha/10-documents.js
+++ b/test/mocha/10-documents.js
@@ -26,6 +26,36 @@ describe('documents.register()', () => {
     isRegistration(result);
   });
 
+  it('should error when an empty recipients array is passed', async () => {
+    const recipients = [];
+    const document = {example: 'document'};
+    let err;
+    try {
+      await documents.register({document, recipients});
+    } catch(e) {
+      err = e;
+    }
+    err.name.should.equal('TypeError');
+    err.message.should.equal('"recipients" must be a non-empty array.');
+    err.should.have.property('details');
+    err.details.should.have.property('httpStatusCode', 400);
+  });
+
+  it('should error when an empty recipientChain array is passed', async () => {
+    const recipientChain = [];
+    const document = {example: 'document'};
+    let err;
+    try {
+      await documents.register({document, recipientChain});
+    } catch(e) {
+      err = e;
+    }
+    err.name.should.equal('TypeError');
+    err.message.should.equal('"recipientChain" must be a non-empty array.');
+    err.should.have.property('details');
+    err.details.should.have.property('httpStatusCode', 400);
+  });
+
   it.skip('should register a document with creator', async () => {
     const result = await documents.register({
       externalId: 'did:test:register:with:data',

--- a/test/mocha/10-documents.js
+++ b/test/mocha/10-documents.js
@@ -121,7 +121,7 @@ describe('documents.register()', () => {
   });
 });
 
-describe('documents.encrypt()', () => {
+describe('documents._encrypt()', () => {
   it('should encrypt a document with recipients', async () => {
     const recipients = [
       {header: {kid: key1.id, alg: 'ECDH-ES+A256KW'}},
@@ -129,7 +129,7 @@ describe('documents.encrypt()', () => {
     ];
 
     const document = {example: 'document'};
-    const jwe = await documents.encrypt({document, recipients});
+    const jwe = await documents._encrypt({document, recipients});
 
     jwe.recipients.should.be.an('array');
     jwe.recipients.length.should.equal(2);
@@ -147,7 +147,7 @@ describe('documents.encrypt()', () => {
     ];
 
     const document = {example: 'document'};
-    const outerJwe = await documents.encrypt({document, recipientChain});
+    const outerJwe = await documents._encrypt({document, recipientChain});
 
     outerJwe.recipients.should.be.an('array');
     outerJwe.recipients.length.should.equal(1);

--- a/test/package.json
+++ b/test/package.json
@@ -34,8 +34,10 @@
     "bedrock-zcap-storage": "^3.0.0",
     "canonicalize": "^1.0.1",
     "cross-env": "^7.0.2",
+    "minimal-cipher": "^1.4.0",
     "nyc": "^15.0.1",
-    "sinon": "^9.0.2"
+    "sinon": "^9.0.2",
+    "x25519-key-pair": "^3.1.0"
   },
   "nyc": {
     "excludeNodeModules": false,


### PR DESCRIPTION
To enable to double-wrap (sequentially encrypt) the tokenized document.