### PR TITLE
Return interalId from tokens.resolve.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## 5.1.0 - 2021-xx-xx
 
 ### Added
-- `tokens.resolve` now returns `internalId` along with existing `pairwiseToken`.
+- `tokens.resolve` now returns `internalId` along with existing `pairwiseToken`. While this is
+  a backwards-compatible change, callers should ensure that `internalId` is not leaked beyond
+  any important trust boundaries (e.g., not to the party that requested resolution).
   While this is a backwards-compatible change, callers should ensure that
   `internalId` is not leaked beyond any important trust boundaries (e.g., not
   to the party that requested resolution).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `tokens.resolve` now returns `internalId` along with existing `pairwiseToken`.
   While this is a backwards-compatible change, callers should ensure that
   `internalId` is not leaked beyond any important trust boundaries (e.g., not
-    to the party that requested resolution).
+  to the party that requested resolution).
 
 ## 5.0.0 - 2021-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 - `tokens.resolve` now returns `internalId` along with existing `pairwiseToken`.
+  While this is a backwards-compatible change, callers should ensure that
+  `internalId` is not leaked beyond any important trust boundaries (e.g., not
+    to the party that requested resolution).
 
 ## 5.0.0 - 2021-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-tokenization ChangeLog
 
+## 5.1.0 - 2021-xx-xx
+
+### Added
+- `tokens.resolve` now returns `internalId` along with existing `pairwiseToken`.
+
 ## 5.0.0 - 2021-05-05
 
 ### Added

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -503,7 +503,7 @@ export async function resolve({requester, token, levelOfAssurance}) {
     }
 
     // return new pairwise token
-    return {pairwiseToken};
+    return {pairwiseToken, internalId};
   }
 }
 


### PR DESCRIPTION
I listed this as a minor release, as it is backwards compatible with the tests we have.