### PR TITLE
Add check for undefined entity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # bedrock-tokenization ChangeLog
 
-## 5.2.0 - 2021-xx-xx
+## 5.1.1 - 2021-06-xx
 
 ### Fixed
 - Added a fix to create entities for existing registrations. This only applies to
   versions prior to 5.0.0, since new entities are automatically created.
 
-## 5.1.0 - 2021-05-1
+## 5.1.0 - 2021-05-01
 
 ### Added
 - `tokens.resolve` now returns `internalId` along with existing `pairwiseToken`. While this is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-tokenization ChangeLog
 
+## 5.2.0 - 2021-xx-xx
+
+### Fixed
+- Added a fix to create entities for existing registrations. This only applies to
+  versions prior to 5.0.0, since new entities are automatically created.
+
 ## 5.1.0 - 2021-05-1
 
 ### Added

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -149,24 +149,26 @@ export async function register({
       // the record matches the one passed in as the docs state
       let upsertEntityPromise;
       if(internalId) {
-        // resolve the promise to an error if it rejects to avoid an unhandled
-        // rejection later; check the result to see if it is an error and throw
         upsertEntityPromise = entities._upsert(
-          {internalId, ttl, minAssuranceForResolution}).catch(e => e);
+          {internalId, ttl, minAssuranceForResolution});
       }
 
-      if(await _refresh({externalIdHash, documentHash, ttl, creatorHash})) {
+      // concurrently attempt to refresh an existing registration and upsert
+      // the associated entity (if `internalId` was given)
+      const [{updated, record}, upsertEntityResult] = await Promise.all([
+        _refresh({externalIdHash, documentHash, ttl, creatorHash}),
+        upsertEntityPromise
+      ]);
+      if(updated) {
         // doc already registered and now refreshed, no need to encrypt; just
-        // fetch existing record and await entity upsert in parallel; then
-        // return fetched record
-        const [record, upsertEntityResult] = await Promise.all([
-          _getRegistrationRecord({externalIdHash, documentHash}),
-          upsertEntityPromise
-        ]);
-        if(upsertEntityResult instanceof Error) {
-          throw upsertEntityResult;
-        }
+        // ensure entity is also refreshed
         if(!upsertEntityResult) {
+          /* Note: This code path should be very uncommon if systems are
+          checking for an existing registration (and fetching the `internalId`
+          prior to calling `register`); in which case `entities._upsert` will
+          run in parallel alongside `_refresh` and both should succeed in the
+          common case. Taking that approach would yield the lowest-latency
+          approach to registration, whereas this would be the slowest. */
           await entities._upsert({
             internalId: record.registration.internalId,
             ttl, minAssuranceForResolution
@@ -440,10 +442,16 @@ async function _refresh({
     };
   }
   const collection = database.collections['tokenization-registration'];
-  const result = await collection.updateOne(
-    query, update, database.writeOptions);
-  // return `true` if the update occurred
-  return result.result.n !== 0;
+  const projection = {_id: 0};
+  const result = await collection.findOneAndUpdate(
+    query, update, {
+      projection,
+      returnNewDocument: true,
+      promoteBuffers: true,
+      ...database.writeOptions
+    });
+  // return whether update occurred and new record if it did
+  return {updated: result.lastErrorObject.n !== 0, record: result.value};
 }
 
 async function _hmacDocument({hmac, document}) {

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -166,6 +166,12 @@ export async function register({
         if(upsertEntityResult instanceof Error) {
           throw upsertEntityResult;
         }
+        if(!upsertEntityResult) {
+          await entities._upsert({
+            internalId: record.registration.internalId,
+            ttl, minAssuranceForResolution
+          });
+        }
         return record;
       }
     }


### PR DESCRIPTION
This fixes the issue where registrations that were created prior to version 5.0.0 did not have an entity, and one was not being automatically created for them.