### PR TITLE
Set `batchInvalidationCount` default to 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-tokenization ChangeLog
 
+## 7.1.0 - 2021-xx-xx
+
+### Changed
+- Set `batchInvalidationCount` to 0 when created.
+
 ## 7.0.0 - 2021-06-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # bedrock-tokenization ChangeLog
 
-## 7.1.0 - 2021-xx-xx
+## 7.0.1 - 2021-xx-xx
 
-### Changed
-- Set `batchInvalidationCount` to 0 when created.
+### Fixed
+- Added `batchInvalidationCount` as a parameter to `_insertBatch`.
 
 ## 7.0.0 - 2021-06-15
 

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1057,7 +1057,7 @@ async function _getUnfilledBatch({
 }
 
 async function _insertBatch({
-  id, internalId, batchVersion, tokenCount, batchInvalidationCount,
+  id, internalId, batchVersion, tokenCount, batchInvalidationCount = 0,
   minAssuranceForResolution = -1
 }) {
   // create bitstring to store whether individual tokens have been

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -817,8 +817,10 @@ async function _createBatch({
   for this module. Furthermore, even under those circumstances, the ideal case
   may still occur. */
   const [record] = await Promise.all([
-    _insertBatch(
-      {id, internalId, batchVersion, tokenCount, minAssuranceForResolution}),
+    _insertBatch({
+      id, internalId, batchVersion, tokenCount, minAssuranceForResolution,
+      batchInvalidationCount
+    }),
     entities._setOpenTokenBatchId({
       internalId, batchId: id, batchInvalidationCount,
       minAssuranceForResolution
@@ -1057,7 +1059,7 @@ async function _getUnfilledBatch({
 }
 
 async function _insertBatch({
-  id, internalId, batchVersion, tokenCount, batchInvalidationCount = 0,
+  id, internalId, batchVersion, tokenCount, batchInvalidationCount,
   minAssuranceForResolution = -1
 }) {
   // create bitstring to store whether individual tokens have been


### PR DESCRIPTION
If `batchInvalidationCount` was not passed into `_insertBatch` it would default to null in the database.