### PR TITLE
Add flag to throw error if token was previously resolved.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # bedrock-tokenization ChangeLog
 
+## 9.0.0 - 2021-xx-xx
+
+### Changed
+- **BREAKING**: Added default `false` flag `allowInvalidTokens` flag to
+  `resolve`. If the same requester tries to resolve a previously resolved token,
+  it will now throw an error.
+
+### Fixed
+- Added missing return value `internalId` from `resolve`.
+
 ## 8.0.0 - 2021-xx-xx
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,6 @@
 # bedrock-tokenization ChangeLog
 
-## 9.0.0 - 2021-xx-xx
-
-### Changed
-- **BREAKING**: Added default `false` flag `allowInvalidTokens` flag to
-  `resolve`. If the same requester tries to resolve a previously resolved token,
-  it will now throw an error.
+## 8.1.0 - 2021-xx-xx
 
 ### Fixed
 - Added missing return value `internalId` from `resolve`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # bedrock-tokenization ChangeLog
 
-## 8.1.0 - 2021-xx-xx
+## 9.0.0 - 2021-xx-xx
+
+### Changed
+- **BREAKING**: Added default `false` flag `allowResolvedInvalidatedTokens` to
+  `resolve`. Setting this flag to true will allow already resolved but
+  subsequently invalidated tokens to be resolved again.
 
 ### Fixed
 - Added missing return value `internalId` from `resolve`.

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -408,7 +408,7 @@ export async function resolve({requester, token, levelOfAssurance}) {
           // token resolved for same requester, return pairwise token
           const record = await _getPairwiseToken({internalId, requester});
           const {pairwiseToken: {value: pairwiseToken}} = record;
-          return {pairwiseToken};
+          return {pairwiseToken, internalId};
         }
       }
       // token already resolved to another requester, can only be

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -350,8 +350,9 @@ export async function create({
  * @param {Buffer} options.token - Decoded scoped token to resolve.
  * @param {number} options.levelOfAssurance - Level of assurance provided
  *   during token presentation.
- * @param {boolean} options.allowResolvedInvalidatedTokens - If true, will allow
- *   already resolved but subsequently invalidated tokens to be resolved again.
+ * @param {boolean} [options.allowResolvedInvalidatedTokens=false] - If true,
+ *   will allow already resolved but subsequently invalidated tokens to be
+ *   resolved again.
  *
  * @returns {object} An object containing the Uint8Array `pairwiseToken`.
  */
@@ -420,8 +421,8 @@ export async function resolve({
         }
       }
       if(!tokenRecord) {
-      // token already resolved to another requester, can only be
-      // scope-resolved once
+        // token already resolved to another requester, can only be
+        // scope-resolved once
         throw new BedrockError(
           'Token already used.',
           'NotAllowedError', {
@@ -453,6 +454,8 @@ export async function resolve({
     }
 
     if(tokenRecord) {
+      // token was previously resolved and we now know it hasn't been
+      // invalidated, so now it can be returned
       const {pairwiseToken: {value: pairwiseToken}} = tokenRecord;
       return {pairwiseToken, internalId};
     }

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -350,14 +350,10 @@ export async function create({
  * @param {Buffer} options.token - Decoded scoped token to resolve.
  * @param {number} options.levelOfAssurance - Level of assurance provided
  *   during token presentation.
- * @param {boolean} options.allowInvalidTokens - If returning previously
- *   resolved tokens is allowed.
  *
  * @returns {object} An object containing the Uint8Array `pairwiseToken`.
  */
-export async function resolve({
-  requester, token, levelOfAssurance, allowInvalidTokens = false
-}) {
+export async function resolve({requester, token, levelOfAssurance}) {
   // parse token
   const {batchId, index} = await _parseToken({token});
 
@@ -412,9 +408,7 @@ export async function resolve({
           // token resolved for same requester, return pairwise token
           const record = await _getPairwiseToken({internalId, requester});
           const {pairwiseToken: {value: pairwiseToken}} = record;
-          if(allowInvalidTokens) {
-            return {pairwiseToken, internalId};
-          }
+          return {pairwiseToken, internalId};
         }
       }
       // token already resolved to another requester, can only be

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -350,10 +350,14 @@ export async function create({
  * @param {Buffer} options.token - Decoded scoped token to resolve.
  * @param {number} options.levelOfAssurance - Level of assurance provided
  *   during token presentation.
+ * @param {boolean} options.allowInvalidTokens - If returning previously
+ *   resolved tokens is allowed.
  *
  * @returns {object} An object containing the Uint8Array `pairwiseToken`.
  */
-export async function resolve({requester, token, levelOfAssurance}) {
+export async function resolve({
+  requester, token, levelOfAssurance, allowInvalidTokens = false
+}) {
   // parse token
   const {batchId, index} = await _parseToken({token});
 
@@ -408,7 +412,9 @@ export async function resolve({requester, token, levelOfAssurance}) {
           // token resolved for same requester, return pairwise token
           const record = await _getPairwiseToken({internalId, requester});
           const {pairwiseToken: {value: pairwiseToken}} = record;
-          return {pairwiseToken, internalId};
+          if(allowInvalidTokens) {
+            return {pairwiseToken, internalId};
+          }
         }
       }
       // token already resolved to another requester, can only be

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -350,10 +350,14 @@ export async function create({
  * @param {Buffer} options.token - Decoded scoped token to resolve.
  * @param {number} options.levelOfAssurance - Level of assurance provided
  *   during token presentation.
+ * @param {boolean} options.allowResolvedInvalidatedTokens - If true, will allow
+ *   already resolved but subsequently invalidated tokens to be resolved again.
  *
  * @returns {object} An object containing the Uint8Array `pairwiseToken`.
  */
-export async function resolve({requester, token, levelOfAssurance}) {
+export async function resolve({
+  requester, token, levelOfAssurance, allowResolvedInvalidatedTokens = false
+}) {
   // parse token
   const {batchId, index} = await _parseToken({token});
 
@@ -396,6 +400,8 @@ export async function resolve({requester, token, levelOfAssurance}) {
     let requesterList = resolution[encodedRequester];
 
     // see if token is already resolved
+    let tokenRecord;
+
     // Note: Unpinned token batch invalidation is not retroactive; if a token
     // was already resolved before invalidation, it remains resolved.
     if(resolvedList.get(index)) {
@@ -406,19 +412,23 @@ export async function resolve({requester, token, levelOfAssurance}) {
         });
         if(bs.get(index)) {
           // token resolved for same requester, return pairwise token
-          const record = await _getPairwiseToken({internalId, requester});
-          const {pairwiseToken: {value: pairwiseToken}} = record;
-          return {pairwiseToken, internalId};
+          tokenRecord = await _getPairwiseToken({internalId, requester});
+          if(allowResolvedInvalidatedTokens) {
+            const {pairwiseToken: {value: pairwiseToken}} = tokenRecord;
+            return {pairwiseToken, internalId};
+          }
         }
       }
+      if(!tokenRecord) {
       // token already resolved to another requester, can only be
       // scope-resolved once
-      throw new BedrockError(
-        'Token already used.',
-        'NotAllowedError', {
-          public: true,
-          httpStatusCode: 400
-        });
+        throw new BedrockError(
+          'Token already used.',
+          'NotAllowedError', {
+            public: true,
+            httpStatusCode: 400
+          });
+      }
     }
 
     // await any parallel potential entity record lookup to check for
@@ -440,6 +450,11 @@ export async function resolve({requester, token, levelOfAssurance}) {
           public: true,
           httpStatusCode: 403
         });
+    }
+
+    if(tokenRecord) {
+      const {pairwiseToken: {value: pairwiseToken}} = tokenRecord;
+      return {pairwiseToken, internalId};
     }
 
     // token is not yet resolved, attempt to resolve it for `requester`...

--- a/test/mocha/20-tokens.js
+++ b/test/mocha/20-tokens.js
@@ -200,7 +200,9 @@ describe('Tokens', function() {
       const result1 = await tokens.resolve({requester, token});
       try {
         // resolve token with same requester again
-        result2 = await tokens.resolve({requester, token});
+        result2 = await tokens.resolve({
+          requester, token, allowInvalidTokens: true
+        });
       } catch(e) {
         err = e;
       }
@@ -209,6 +211,35 @@ describe('Tokens', function() {
       should.exist(result1.pairwiseToken);
       should.exist(result2.pairwiseToken);
       result1.pairwiseToken.should.deep.equal(result2.pairwiseToken);
+    });
+  it('should throw error when called twice by "requester" with no allow flag',
+    async function() {
+      const tokenCount = 1;
+      const internalId = await documents._generateInternalId();
+      const attributes = new Uint8Array([1]);
+      const requester = 'requester';
+      let err;
+      let result2;
+
+      // upsert mock entity the token is for
+      await entities._upsert({internalId, ttl: 60000});
+
+      const tks = await tokens.create(
+        {internalId, attributes, tokenCount});
+      const token = tks.tokens[0];
+      const result1 = await tokens.resolve({requester, token});
+      try {
+        // resolve token with same requester again
+        result2 = await tokens.resolve({requester, token});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      areTokens(tks);
+      should.exist(result1.pairwiseToken);
+      should.not.exist(result2);
+      err.name.should.equal('NotAllowedError');
+      err.message.should.equal('Token already used.');
     });
   it('should throw error when token is resolved with different "requester"',
     async function() {

--- a/test/mocha/20-tokens.js
+++ b/test/mocha/20-tokens.js
@@ -210,36 +210,8 @@ describe('Tokens', function() {
       areTokens(tks);
       should.exist(result1.pairwiseToken);
       should.exist(result2.pairwiseToken);
-      result1.pairwiseToken.should.deep.equal(result2.pairwiseToken);
-    });
-  it('should throw error when called twice by "requester" with no allow flag',
-    async function() {
-      const tokenCount = 1;
-      const internalId = await documents._generateInternalId();
-      const attributes = new Uint8Array([1]);
-      const requester = 'requester';
-      let err;
-      let result2;
-
-      // upsert mock entity the token is for
-      await entities._upsert({internalId, ttl: 60000});
-
-      const tks = await tokens.create(
-        {internalId, attributes, tokenCount});
-      const token = tks.tokens[0];
-      const result1 = await tokens.resolve({requester, token});
-      try {
-        // resolve token with same requester again
-        result2 = await tokens.resolve({requester, token});
-      } catch(e) {
-        err = e;
-      }
-      should.exist(err);
-      areTokens(tks);
-      should.exist(result1.pairwiseToken);
-      should.not.exist(result2);
-      err.name.should.equal('NotAllowedError');
-      err.message.should.equal('Token already used.');
+      result1.pairwiseToken.should.eql(result2.pairwiseToken);
+      result2.internalId.should.eql(internalId);
     });
   it('should throw error when token is resolved with different "requester"',
     async function() {
@@ -407,7 +379,7 @@ describe('Tokens', function() {
     assertNoError(err);
     should.exist(result);
     result.should.be.an('object');
-    result.should.deep.equal({internalId});
+    result.should.eql({internalId});
   });
   it('should throw error when wrapped value fails to get decrypted',
     async function() {


### PR DESCRIPTION
If a token was previously resolved by the same requester, it previously returned the `pairwiseToken` and `internalId`. This PR fixes a bug where one return only returned `pairwiseToken`, so it will now also return `internalId`.

This PR adds flag `allowInvalidTokens` to the `resolve` endpoint, which defaults to `false`. If the flag is `false`, it will throw an error that the token has already been resolved if the same requester tries to resolve the same token again.