### PR TITLE
Improve checks on last assurance-failed token batch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@
   resolve based on assurance not being met.
 - Allow full `entity` to be passed to `setMinAssuranceForResolution` to
   enable the call to return `false` if the entity's `batchInvalidationCount`
-  has changed. This allows the caller to be sure that no concurrent batch
-  invalidation events occur.
+  has changed or if there is no tracked assurance-failed token resolution.
+  This allows the caller to be sure that no batch invalidation events after
+  the last time a token failed resolution because of a level of assurance
+  that was too low.
 
 ## 16.0.0 - 2022-11-02
 

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -89,13 +89,21 @@ export async function get({internalId, explain = false} = {}) {
  * @param {number} options.minAssuranceForResolution - Minimum level of
  *   identity assurance required for resolution of tokens that were issued
  *   from an unpinned token batch.
+ * @param {object} [options.requireAssuranceFailedTokenResolution=true] - If
+ *   `true`, require that the entity has a non-invalidated token resolution
+ *   failure, i.e., an attempt was made to resolve an unpinned token that
+ *   failed because the level of assurance was too low; requiring this
+ *   automatically checks the last token that failed an assurance check was
+ *   from a non-invalidated batch when `minAssuranceForResolution` was changed
+ *   (if `true` is returned).
  * @param {boolean} [options.explain] - An optional explain boolean.
  *
  * @returns {Promise<boolean | ExplainObject>} Resolves with true if update
  *   occurred or an ExplainObject if `explain=true`.
  */
 export async function setMinAssuranceForResolution({
-  entity, internalId, minAssuranceForResolution, explain = false
+  entity, internalId, minAssuranceForResolution,
+  requireAssuranceFailedTokenResolution = true, explain = false
 } = {}) {
   if(internalId && entity) {
     throw new Error('Only one of "internalId" or "entity" is allowed.');
@@ -110,6 +118,16 @@ export async function setMinAssuranceForResolution({
       entity.batchInvalidationCount, 'entity.batchInvalidationCount');
   } else {
     assert.buffer(internalId, 'internalId');
+  }
+
+  // auto-check `lastAssuranceFailedTokenBatch`
+  if(entity && requireAssuranceFailedTokenResolution && !explain) {
+    // either no last assurance-failed resolution or the token batch used
+    // has been invalidated
+    if(entity.lastAssuranceFailedTokenBatch?.batchInvalidationCount !==
+      entity.batchInvalidationCount) {
+      return false;
+    }
   }
 
   const query = {'entity.internalId': internalId ?? entity.internalId};
@@ -223,8 +241,8 @@ export async function _remove({internalId, explain = false} = {}) {
 }
 
 /**
- * Sets the `batchId` for the token that last failed resolution due to a
- * level of assurance that was too low. This information can be used later
+ * Sets some batch information for the token that last failed resolution due to
+ * a level of assurance that was too low. This information can be used later
  * to check whether the associated token batch has been invalidated since
  * the failed resolution occurred. This is useful for cases where failed
  * token resolutions (due to low level of assurance) trigger increased level of
@@ -235,15 +253,21 @@ export async function _remove({internalId, explain = false} = {}) {
  *
  * @param {object} options - Options to use.
  * @param {object} options.entity - The entity.
- * @param {number} options.batchId - The batch ID to set.
+ * @param {number} options.tokenBatch - The token batch to track.
  *
  * @returns {Promise<boolean>} Resolves with true if update occurred.
  */
-export async function _setLastAssuranceFailedBatchId({entity, batchId} = {}) {
+export async function _setLastAssuranceFailedTokenBatch({
+  entity, tokenBatch
+} = {}) {
   const query = {'entity.internalId': entity.internalId};
   const $set = {
     'meta.updated': Date.now(),
-    'entity.lastAssuranceFailedBatchId': batchId
+    'entity.lastAssuranceFailedTokenBatch': {
+      // track specific batch and its batch invalidation count
+      id: tokenBatch.id,
+      batchInvalidationCount: tokenBatch.batchInvalidationCount
+    }
   };
   const collection = database.collections['tokenization-entity'];
   const result = await collection.updateOne(query, {$set});

--- a/lib/tokens/resolve.js
+++ b/lib/tokens/resolve.js
@@ -195,7 +195,7 @@ export async function resolve({
       // lowering entity's `minAssuranceForResolution`
       if(isUnpinned) {
         const {entity} = entityRecord;
-        await entities._setLastAssuranceFailedBatchId({entity, batchId});
+        await entities._setLastAssuranceFailedTokenBatch({entity, tokenBatch});
       }
       throw new BedrockError(
         'Could not resolve token; minimum level of assurance not met.',


### PR DESCRIPTION
- Auto-check for the presence of a still-valid, assurance-failed token batch resolution in an entity prior to allowing its `minAssuranceForResolution` to be changed.